### PR TITLE
Update matrix-tests.yml

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -39,5 +39,6 @@ jobs:
 
     - name: Run tests
       run: poetry run pytest tests/ --doctest-modules
+      timeout-minutes: 10
 
 


### PR DESCRIPTION
24_10_31_15_20_00 actions is hanging up on 3.9 / ubuntu & windows. it appears that the tests are completing but actions is hanging up before the start of the environment teardown. put timeout-minutes: 10 to see if this resolves the issue.