### PR TITLE
Create matrix-tests-py39.yml

### DIFF
--- a/.github/workflows/matrix-tests-py39.yml
+++ b/.github/workflows/matrix-tests-py39.yml
@@ -1,0 +1,42 @@
+name: Matrix Testing
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.9']
+        
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    # Conditional step to install libomp on macOS
+    # Need libomp on macOS to run XGBoost
+    - name: Install libomp on macOS
+      if: matrix.os == 'macos-latest'
+      run: brew install libomp
+
+    - name: Install Poetry
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+
+    - name: Install dependencies with Poetry
+      run: |
+        poetry lock
+        poetry install
+
+    - name: Run tests
+      run: poetry run pytest tests/ --doctest-modules -v --maxfail=1 --disable-warnings
+      timeout-minutes: 120


### PR DESCRIPTION
24_11_12_09_31_00 create yml for testing py39 separately. GH Actions is not correctly tearing down tests at the end with py39, but all the tests are passing otherwise.