### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ pybear
 
 .. |Build Status| image:: https://github.com/PylarBear/pybear/actions/workflows/python-publish.yml/badge.svg
    :target: https://github.com/PylarBear/pybear/actions/workflows/python-publish.yml
-.. |Test Status| image:: https://github.com/PylarBear/pybear/actions/workflows/matrix-tests.yml/badge.svg
+.. |Test Status| image:: https://github.com/PylarBear/pybear/actions/workflows/matrix-tests-py310+.yml/badge.svg
    :target: https://github.com/PylarBear/pybear/actions/workflows/matrix-tests.yml
 .. |Doc Status| image:: https://readthedocs.org/projects/ml/badge/?version=latest
    :target: //pybear.readthedocs.io/


### PR DESCRIPTION
24_11_12_09_48_00 fix badge for matrix tests, only links to py310+ now.