### PR TITLE
Update testpypi-publish.yml

### DIFF
--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -27,6 +27,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
+      - name: Install LLVM and dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libomp-dev
   
       - name: Install pip, poetry, & dependencies
         run: |


### PR DESCRIPTION
New error 25_01_31 (did not error 24_12_31 with same yml). Could not find llvm-config binary. Update TestPyPI publish yaml with llvmlite dependencies.