### PR TITLE
Update dependency versions in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,38 +26,38 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.10"
 joblib = [
-    {version = "==1.3.0", python = "<3.14"},
-    {version = "==1.5.3", python = "==3.14"}   # check 1.5.2
+    {version = "==1.2.0", python = "<3.14"},   # was 1.3.0
+    {version = "==1.5.2", python = "==3.14"}   # was 1.5.3
 ]
 numpy = [
-    {version = "==2.1.0", python = "<3.14"},
-    {version = "==2.3.2", python = "==3.14"}
+    {version = "==2.0.2", python = "<3.14"},   # was 2.1.0
+    {version = "==2.3.0", python = "==3.14"}   # was 2.3.1  keep this 2.3.1
 ]
 pandas = [
-    {version = "==2.2.3", python = "<3.14"},
-    {version = "==2.3.3", python = "==3.14"}
+    {version = "==2.2.2", python = "<3.14"},  # was 2.2.3
+    {version = "==2.3.2", python = "==3.14"}  # was 2.3.3  keep this 2.3.3
 ]
 polars = [
-    {version = "==1.19.0", python = "<3.14"},
-    {version = "==1.19.0", python = "==3.14"}
+    {version = "==1.18.0", python = "<3.14"},  # was 1.19.0
+    {version = "==1.18.0", python = "==3.14"}  # was 1.19.0
 ]
 psutil = [
     {version = "==5.7.0", python = "<3.14"},
     {version = "==5.7.0", python = "==3.14"}
 ]
 scipy = [
-    {version = "==1.15.0,<1.16.0", python = "==3.10"},  # find lower bound for py3.10
-    {version = "==1.16.1", python = ">=3.11,<3.14"},
-    {version = "==1.16.1", python = "==3.14"},
+    {version = "==1.14.1,<1.16.0", python = "==3.10"},  # was 1.15.0
+    {version = "==1.16.0", python = ">=3.11,<3.14"},  # was 1.16.1
+    {version = "==1.16.0", python = "==3.14"},  # was 1.16.1
 ]
 scikit-learn = [
-    {version = "==1.5.2,<1.8.0", python = "==3.10"},  # find lower bound for py3.10
-    {version = "==1.5.2", python = ">=3.11,<3.14"},   # check starting at 1.6.0
-    {version = "==1.8.0", python = "==3.14"}   # check starting at 1.6.0
+    {version = "==1.5.1,<1.8.0", python = "==3.10"},  # was 1.5.2
+    {version = "==1.5.1", python = ">=3.11,<3.14"},   # was 1.5.2
+    {version = "==1.6.0", python = "==3.14"}   # was 1.8.0
 ]
 typing_extensions = [
-    {version = "==4.12.0", python = "<3.14"},
-    {version = "==4.12.0", python = "==3.14"}
+    {version = "==4.11.0", python = "<3.14"},  # was 4.12.0
+    {version = "==4.11.0", python = "==3.14"}  # was 4.12.0
 ]
 
 
@@ -78,8 +78,8 @@ sphinx-sitemap = "*"
 
 [tool.poetry.group.test.dependencies]
 pytest = [
-    {version = "==7.0.0", python = "<3.14"},
-    {version = "==8.0.0", python = "==3.14"}    # 7.0.0 does not work. check >7.0.0,<8.0.0
+    {version = "==6.2.5", python = "<3.14"},  # was 7.0.0
+    {version = "==7.0.1", python = "==3.14"}    # was 8.0.0
 ]
 pytest-cov = "*"
 pytest-html = "*"


### PR DESCRIPTION
Updated dependency versions for joblib, numpy, pandas, polars, scipy, scikit-learn, typing_extensions, and pytest in pyproject.toml.