### PR TITLE
Change numpy version to 1.26.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ joblib = [
     {version = "==1.5.2", python = "==3.14"}    # was 1.5.3
 ]
 numpy = [
-    {version = "==2.0.1", python = "==3.10"},   # was 2.1.0, 2.02 works
-	{version = "==2.0.1", python = "==3.11"},   # was 2.1.0, 2.02 works
-	{version = "==2.0.1", python = "==3.12"},   # was 2.1.0, 2.02 works
-	{version = "==2.0.2", python = "==3.13"},   # was 2.1.0, 2.02 works
+    {version = "==1.26.4", python = "==3.10"},   # was 2.1.0, 2.02 works
+	{version = "==1.26.4", python = "==3.11"},   # was 2.1.0, 2.02 works
+	{version = "==1.26.4", python = "==3.12"},   # was 2.1.0, 2.02 works
+	{version = "==1.26.4", python = "==3.13"},   # was 2.1.0, 2.02 works
     {version = "==2.3.0", python = "==3.14"}    # was 2.3.1  keep this 2.3.1
 ]
 pandas = [


### PR DESCRIPTION
Updated numpy version to 1.26.4 for multiple Python versions.